### PR TITLE
Fixed - issue #23 - automatization of past, present, future events/conferences based on current date

### DIFF
--- a/pages/conferences.vue
+++ b/pages/conferences.vue
@@ -91,8 +91,8 @@ in order to work correctly with automized rendering. For example:
 	link: 'https://braiins.com/bitcoin-mining-conference-2022',
 	location: 'Prague / CZ',
 	displayDates: '14-16 Giugno 2022',
-	startDate: '14 June 2022 10:30:00 GMT+2',
-	endDate: '16 June 2022 23:59:00 GMT+2'
+	startDate: '14 June 2022',
+	endDate: '16 June 2022'
 }
 */
 let conferencesList = [  

--- a/pages/conferences.vue
+++ b/pages/conferences.vue
@@ -5,9 +5,26 @@
 
 		<p>Queste sono conferenze o eventi dal vivo a tema solo Bitcoin.</p>
 
-		<h3>Programmati</h3>
+		<div v-if="ongoingConferences.length!=0" class="tbl-scroller">
+			<h3>In corso</h3>
+			<div class="tbl-wrapper">
+				<div class="tbl-header">
+					<div class="tbl-title">Conferenza</div>
+					<div class="tbl-title">Luogo</div>
+					<div class="tbl-title">Data</div>
+				</div>
+				<div v-for="(lineItem, index) in ongoingConferences" :key="index" class="tbl-row">
+					<div>
+						<a :href="lineItem.link" target="_blank">{{ lineItem.title }}</a>
+					</div>
+					<div v-html="lineItem.location"></div>
+					<div v-html="lineItem.displayDates"></div>
+				</div>
+			</div>
+		</div>
 
-		<div class="tbl-scroller">
+		<div v-if="upcomingConferences.length!=0" class="tbl-scroller">
+			<h3>Programmate</h3>
 			<div class="tbl-wrapper">
 				<div class="tbl-header">
 					<div class="tbl-title">Conferenza</div>
@@ -19,7 +36,27 @@
 						<a :href="lineItem.link" target="_blank">{{ lineItem.title }}</a>
 					</div>
 					<div v-html="lineItem.location"></div>
-					<div v-html="lineItem.dates"></div>
+					<div v-html="lineItem.displayDates"></div>
+				</div>
+			</div>
+		</div>
+
+		
+
+		<div v-if="pastConferences.length!=0" class="tbl-scroller">
+			<h3>Passate</h3>
+			<div class="tbl-wrapper">
+				<div class="tbl-header">
+					<div class="tbl-title">Conferenza</div>
+					<div class="tbl-title">Luogo</div>
+					<div class="tbl-title">Data</div>
+				</div>
+				<div v-for="(lineItem, index) in pastConferences" :key="index" class="tbl-row">
+					<div>
+						<a :href="lineItem.link" target="_blank">{{ lineItem.title }}</a>
+					</div>
+					<div v-html="lineItem.location"></div>
+					<div v-html="lineItem.displayDates"></div>
 				</div>
 			</div>
 		</div>
@@ -46,6 +83,95 @@ h3 {
 </style>
 
 <script>
+
+/* Objects in conferencesList will always need a 'startDate' and 'endDate' field 
+in order to work correctly with automized rendering. For example:
+{
+	title: 'The Bitcoin Mining Conference',
+	link: 'https://braiins.com/bitcoin-mining-conference-2022',
+	location: 'Prague / CZ',
+	displayDates: '14-16 Giugno 2022',
+	startDate: '14 June 2022 10:30:00 GMT+2',
+	endDate: '16 June 2022 23:59:00 GMT+2'
+}
+*/
+let conferencesList = [  
+	{
+		title: 'The Bitcoin Mining Conference',
+		link: 'https://braiins.com/bitcoin-mining-conference-2022',
+		location: 'Prague / CZ',
+		displayDates: '14-16 Giugno 2022',
+		startDate: '14 June 2022',
+		endDate: '16 June 2022',
+	},
+	{
+		title: 'btc++',
+		link: 'https://www.btcplusplus.dev/',
+		location: 'Austin, TX / USA',
+		displayDates: '7-10 Giugno 2022',
+		startDate: '7 June 2022',
+		endDate: '10 June 2022',
+	},
+	{
+		title: 'Bit Block Boom!',
+		link: 'https://bitblockboom.com/',
+		location: 'Austin, TX / USA',
+		displayDates: '25-28 Agosto 2022',
+		startDate: '25 August 2022',
+		endDate: '28 August 2022',
+	},
+	{
+		title: 'BTC22',
+		link: 'https://bconf.de/',
+		location: 'Innsbruck, Austria',
+		displayDates: '15-17 Settembre 2022',
+		startDate: '15 September 2022',
+		endDate: '17 September 2022',
+	},
+	{
+		title: 'Baltic Honey Badger',
+		link: 'https://baltichoneybadger.com/',
+		location: 'Riga, Lettonia',
+		displayDates: '3-4 Settembre 2022',
+		startDate: '3 September 2022',
+		endDate: '4 September 2022',
+	},
+	{
+		title: 'Bitcoin Amsterdam',
+		link: 'https://b.tc/conference/amsterdam',
+		location: 'Amsterdam, Paesi Bassi',
+		displayDates: '12-14 Ottobre 2022',
+		startDate: '12 October 2022',
+		endDate: '13 October 2022',
+	},
+	{
+		title: 'Plan B Forum',
+		link: 'https://planb.lugano.ch/planb-forum/',
+		location: 'Lugano, Svizzera',
+		displayDates: '28-29 Ottobre 2022',
+		startDate: '28 October 2022',
+		endDate: '29 October 2022',
+	}
+];
+
+let pastConferences = [];
+let ongoingConferences = []; 
+let upcomingConferences = [];
+let now = new Date();
+
+conferencesList.forEach((x) => {
+	let startDate = new Date(x.startDate);
+	let endDate = new Date(x.endDate);
+	endDate.setHours(23,59,59); 		//in order to cover the full last day (NOTE: for the startDate isn't necessary,
+										//because it's already set to 00:00:00)
+	if(startDate<=now && endDate>=now) {
+		ongoingConferences.push(x)
+	} else if(startDate>Date.now()) {
+		upcomingConferences.push(x)
+	} else if(endDate<Date.now()) pastConferences.push(x)
+});
+
+
 export default {
 
 	name: 'ConferencesPage',
@@ -57,58 +183,12 @@ export default {
 		]
 	},
 
-	// TODO: Add script to move past confernce based on .now() in a new section
-
 	data() {
 		return {
-
-			upcomingConferences: [
-				{
-					title: 'The Bitcoin Mining Conference',
-					link: 'https://braiins.com/bitcoin-mining-conference-2022',
-					location: 'Prague / CZ',
-					dates: '14-16 Giugno 2022'
-				},
-				{
-					title: 'btc++',
-					link: 'https://www.btcplusplus.dev/',
-					location: 'Austin, TX / USA',
-					dates: '7-10 Giugno 2022'
-				},
-				{
-					title: 'Bit Block Boom!',
-					link: 'https://bitblockboom.com/',
-					location: 'Austin, TX / USA',
-					dates: '25-28 Agosto 2022'
-				},
-				{
-					title: 'BTC22',
-					link: 'https://bconf.de/',
-					location: 'Innsbruck, Austria',
-					dates: '15-17 Settembre 2022'
-				},
-				{
-					title: 'Baltic Honey Badger',
-					link: 'https://baltichoneybadger.com/',
-					location: 'Riga, Lettonia',
-					dates: '3-4 Settembre 2022'
-				},
-				{
-					title: 'Bitcoin Amsterdam',
-					link: 'https://b.tc/conference/amsterdam',
-					location: 'Amsterdam, Paesi Bassi',
-					dates: '12-14 Ottobre 2022'
-				},
-				{
-					title: 'Plan B Forum',
-					link: 'https://planb.lugano.ch/planb-forum/',
-					location: 'Lugano, Svizzera',
-					dates: '28-29 Ottobre 2022'
-				}
-			],
-			
+			pastConferences,
+			ongoingConferences,
+			upcomingConferences	
 		}
-	}
-
+	},
 }
 </script>


### PR DESCRIPTION
Fix issue #23 
I created a generic object called "conferencesList" which contains all the events (past, present, future).
Then, I created 3 different objects (pastConferences, ongoingConferences, upcomingConferences) which are correctly filled up by the lines contained in the forEach (line 162).
In this way, the only operation to do in the future will be to statically change the primary "conferencesList" (following the example present upthere).