### PR TITLE
Aggiunto "GetAlby" con link a guide in italiano

### DIFF
--- a/pages/wallets.vue
+++ b/pages/wallets.vue
@@ -752,6 +752,12 @@ export default {
           platform: "Web",
         },
         {
+          title: "GetAlby",
+          link: "https://guides.getalby.com/italian-guides/",
+          description: "Your Bitcoin & Nostr companion for the web",
+          platform: "Web",
+        },
+        {
           title: "Opennode",
           link: "https://opennode.co/",
           description: "Accept Bitcoin & Lightning payments",


### PR DESCRIPTION
Aggiunto "GetAlby" nella sezione "Custodial Accounts" della pagina "Wallets" con puntamento url alle guide in italiano.